### PR TITLE
Fix typing issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,9 @@ jobs:
       - run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - run: mypy stellar/
+      - run: mypy
 
-      - run: pyright stellar/
+      - run: pyright
   format:
     runs-on: ubuntu-latest
     steps:

--- a/benchmarks/benchmark_gkp.py
+++ b/benchmarks/benchmark_gkp.py
@@ -1,12 +1,9 @@
-import cProfile
-import time
 from stellar.cvstates import GKPState
 from stellar.params import Method, OptimisationParameters
 from stellar.profile import compute_profile
 
 
 def get_gkp_profile() -> None:
-
     state = GKPState(delta=0.3, kappa=0.3)  # more terms (11 vs 4) than Δ = κ = 0.3
 
     max_rank = 10  # why 20 profile file?
@@ -17,6 +14,7 @@ def get_gkp_profile() -> None:
     # profile_time = time.time()
     # print(f"profile time {profile_time - init_time}")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     # cProfile.run('get_gkp_profile()', sort='ncalls')
     get_gkp_profile()

--- a/scripts/gkp_convergence.py
+++ b/scripts/gkp_convergence.py
@@ -5,9 +5,9 @@ rank = 3 is prone to instability in the standard GKP case.
 sols are 0.62246 or 0.599805.
 """
 
-import logging
 from stellar.cvstates import GKPState
 from stellar.profile import compute_sup_fidelity
+from stellar.params import Method, OptimisationParameters
 
 # logger = logging.getLogger(__name__)
 # logging.basicConfig(filename='gkp.log', encoding='utf-8', level=logging.DEBUG)
@@ -19,7 +19,6 @@ from stellar.profile import compute_sup_fidelity
 # logger.info("Starting GKP script...")
 
 if __name__ == "__main__":
-
     tgt_state = GKPState()
 
     rank = 3
@@ -33,11 +32,10 @@ if __name__ == "__main__":
     # todo add different seed and starting point to check th evalue
     print("Starting...")
     for n in range(100, 600, 100):
-
-        res = compute_sup_fidelity(max_rank=rank, target_state=tgt_state, method="g", niter=n)
+        res = compute_sup_fidelity(
+            max_rank=rank, target_state=tgt_state, optim_params=OptimisationParameters(method=Method.gaussian, niter=n)
+        )
         results.append(-res.fun)
 
     print("Finished!")
     print(f"The results are: {results=}.")
-
-

--- a/stellar/conversion.py
+++ b/stellar/conversion.py
@@ -1,5 +1,5 @@
 from enum import Enum, auto
-from typing import TypeGuard, TypeVar, assert_never
+from typing import TypeVar, assert_never
 import warnings
 
 from stellar.cvstates import HermitianCVOp, PureCVState
@@ -16,16 +16,6 @@ class Protocol(Enum):
     postselected = auto()
 
 
-# union is empty anyways
-# NOTE: is there a better wat to do this?
-S = TypeVar("S", PureCVState, HermitianCVOp)
-T = TypeVar("T", bound=PureCVState)
-
-
-def is_stellar_profile_pure(profile: StellarProfile[S]) -> TypeGuard[StellarProfile[PureCVState]]:
-    return isinstance(profile.state, PureCVState)
-
-
 # both have a defined state type but they can be different
 # equations will also be different ...
 # find a way to filter types.
@@ -33,8 +23,8 @@ def is_stellar_profile_pure(profile: StellarProfile[S]) -> TypeGuard[StellarProf
 def max_trace_distance_precision(
     protocol: Protocol,
     nb_copies: int,
-    to_profile: StellarProfile[T],
-    from_profile: StellarProfile[S] | None = None,
+    to_profile: StellarProfile[PureCVState],
+    from_profile: StellarProfile[PureCVState | HermitianCVOp] | None = None,
     from_rank: int | None = None,
 ) -> float:  # or None? TODO don't understand this typing issue
     # assume contiguous ranks from 0 to max in all cases
@@ -55,9 +45,11 @@ def max_trace_distance_precision(
             raise ValueError(
                 "`from_profile` cannot be None when assessing Gaussian conversion with a non-postselected protocol."
             )
-        if is_stellar_profile_pure(from_profile):
+        if isinstance(from_profile.state, PureCVState):
+            # In this branch, the typer knows that `from_profile.state` has type `PureCVState`,
+            # therefore `from_profile.replace(from_profile.state)` has type `StellarProfile[PureCVState]`.
             return max_trace_distance_precision_pure_pure_std(
-                from_profile=from_profile, to_profile=to_profile, nb_copies=nb_copies
+                from_profile=from_profile.replace(from_profile.state), to_profile=to_profile, nb_copies=nb_copies
             )
         assert isinstance(from_profile.state, HermitianCVOp)
         # TODO to be modified here for mixed states

--- a/stellar/data.py
+++ b/stellar/data.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import json
-from dataclasses import InitVar, dataclass, field
+from collections.abc import Mapping, Iterable
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Generic, Iterator, TypeVar
 
@@ -31,30 +34,40 @@ from stellar.params import Method, OptimisationParameters  # noqa: F401
 # quick fix: dict(zip(ranks, fidelities))
 # TODO add __iter__ function
 # Todo add draw( function)
+S_co = TypeVar("S_co", bound=PureCVState | HermitianCVOp, covariant=True)
 S = TypeVar("S", bound=PureCVState | HermitianCVOp)
 
 
-@dataclass(frozen=True)
-class StellarProfile(Generic[S]):
+@dataclass(frozen=True, init=False)
+class StellarProfile(Generic[S_co]):
     """A dataclass for stellar profiles allowing manipulation and serialization to json."""
 
     # single rank returns a StellarProfile?
     # Combine them by concatenation if different ranks but same state and params.
     # state name of the parameter and _state for the field
     # state: InitVar[S]  # constructor param name = c
-    state: S  # PureCVState | HermitianCVOp
+    state: S_co = field(init=False)  # PureCVState | HermitianCVOp
     # _state: str = field(init=False)  # stored attribute
-    ranks: InitVar[list[int]]
-    fidelities: InitVar[list[float]]
-    profile: dict[int, float] = field(init=False)
-    optim_params: OptimisationParameters | None = None  # TODO remove None
+    ranks: tuple[int]
+    fidelities: tuple[float]
+    profile: Mapping[int, float]
+    optim_params: OptimisationParameters | None  # TODO remove None
 
-    def __post_init__(self, ranks: list[int], fidelities: list[float]) -> None:  # , state: S
-        # object.__setattr__(self, "_state", repr(state))  # same trick since frozen dataclass
-        if len(ranks) != len(fidelities):
+    def __init__(
+        self,
+        state: S_co,
+        ranks: Iterable[int],
+        fidelities: Iterable[float],
+        optim_params: OptimisationParameters | None = None,
+    ) -> None:
+        object.__setattr__(self, "state", state)
+        object.__setattr__(self, "ranks", tuple(ranks))
+        object.__setattr__(self, "fidelities", tuple(fidelities))
+        object.__setattr__(self, "optim_params", optim_params)
+        if len(self.ranks) != len(self.fidelities):
             raise ValueError("The length of ranks and fidelities have to match.")
-        object.__setattr__(self, "profile", dict(zip(ranks, fidelities)))  # same trick since frozen dataclass
-        # self.profile = dict(zip(ranks, fidelities))
+        profile = dict(zip(ranks, fidelities))
+        object.__setattr__(self, "profile", profile)
 
     def __iter__(self) -> Iterator[tuple[int, float]]:  # TODO return type annotate this
         return iter(self.profile.items())
@@ -65,6 +78,9 @@ class StellarProfile(Generic[S]):
             "profile": self.profile,
             "optim_params": repr(self.optim_params),
         }
+
+    def replace(self, state: S) -> StellarProfile[S]:
+        return StellarProfile(state, self.ranks, self.fidelities, self.optim_params)
 
     def save_to_file(self, filename: str, path: Path | None = None) -> None:
         """

--- a/tests/data/test.json
+++ b/tests/data/test.json
@@ -1,7 +1,0 @@
-{
-    "state": "CatState(amplitude=3, parity=False)",
-    "profile": {
-        "0": 0.5000000075920732
-    },
-    "optim_params": "OptimisationParameters(method=Method.gaussian, target_cutoff=None, niter=250, x0=(0.1, 0.1, 0.1, 0.1), seed=None)"
-}

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -54,12 +54,15 @@ def test_det_conversion_fail_mixed() -> None:
     to_profile = compute_profile(ranks=list(range(max_rank)), target_state=to_state, optim_params=pars)
 
     with pytest.raises(ValueError, match="Cannot assess Gaussian conversion to a mixed state."):
-        # manually disable typing warning since want to check the dynamical error
+        # manually disable typing error since want to check the dynamical error
+        # Indeed, `to_profile` variable has type `StellarProfile[HermitianCVOp]` whereas
+        #   `to_profile` parameter expects the type `StellarProfile[PureCVState]`,
+        #    and `HermitianCVOp` is not a subtype of `PureCVState`.
         max_trace_distance_precision(
             protocol=Protocol.standard,
             nb_copies=2,
-            to_profile=to_profile,
-            from_profile=from_profile,  # type: ignore
+            to_profile=to_profile,  # type: ignore
+            from_profile=from_profile,
         )
 
 


### PR DESCRIPTION
This commit makes the typers `mypy` and `pyright` accept all the modules, including `tests` and `scripts`.

`StellarProfile[S]` is declared covariant in `S`, by marking the `state` field with `init=False` to remove it from the auto-method `__replace__`. The `__init__` method is implemented by hand, subsuming the previous `__post_init__`.

Since `StellarProfile` is covariant, `max_trace_distance_precision` does no longer need to use type variables for the type of the states in `to_profile` and `from_profile`. Indeed, the function can use the types `StellarProfile[PureCVState]` and `StellarProfile[PureCVState | HermitianCVOp]` respectively, and the covariance ensures the expected subtyping relations.

Instead of using a `TypeGuard` to refine the type of `StellarProfile` when we check that the state is `PureCVState`, we define a `replace` method in `StellarProfile` to "update" the state with itself, but with a more precise type.

`tests/data/test.json` is removed for the git repository, since it is auto-generated (and ignored).