### PR TITLE
add deterministic conversion protocol bounds for mixed state input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0] - 2026-02-11
+## [Unreleased]
 
 ### Added
+
+- approximate conversion bounds for mixed state with standard protocol.
+
+### Fixed
+
+- [#4](https://github.com/qat-inria/stellar-numerics/pull/4) fixed typing issues by making `StellarProfile` covariant with the type of their state.
+
+## [0.1] - 2026-02-11
+
+### Added
+
 First commit.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- approximate conversion bounds for mixed state with standard protocol.
+- [#6] added approximate Gaussian conversion bounds for mixed state with standard protocol (stellar rank <= 1>).
 
 ### Fixed
 
 - [#4](https://github.com/qat-inria/stellar-numerics/pull/4) fixed typing issues by making `StellarProfile` covariant with the type of their state.
+
+### Changed
+
+- [#6] modified the logic of `max_trace_distance` in `conversion.py` to use pattern matching (`match`/`case` syntax) instead of `if`/`else`.
 
 ## [0.1] - 2026-02-11
 

--- a/stellar/conversion.py
+++ b/stellar/conversion.py
@@ -121,7 +121,7 @@ def max_trace_distance_precision_mixed_pure_std(
     for n in range(0, max_n + 1):
         distance_list.append((1 - to_profile.profile[nb_copies * n] - nb_copies * (1 - from_profile.profile[n])) ** 2)
     print(f"{distance_list=}")
-    # return max(distance_list)
+    return max(distance_list)
 
 
 def max_trace_distance_precision_pure_pure_post(
@@ -140,4 +140,3 @@ def max_trace_distance_precision_mixed_pure_post(
     The actual profile of the target state is not required (only the stellar rank) since it is a looser bound see Eq. (39) [HFFC25]."""
 
     return (1 - to_profile.profile[nb_copies * from_rank]) ** 2
-

--- a/stellar/conversion.py
+++ b/stellar/conversion.py
@@ -37,52 +37,58 @@ def max_trace_distance_precision(
     if isinstance(to_profile.state, HermitianCVOp):
         raise ValueError("Cannot assess Gaussian conversion to a mixed state.")
 
-    # pure -> pure case
-    # requires both profiles explicitely
-
-    if protocol is Protocol.standard:
-        if from_profile is None:
-            raise ValueError(
-                "`from_profile` cannot be None when assessing Gaussian conversion with a non-postselected protocol."
-            )
-        if isinstance(from_profile.state, PureCVState):
-            # In this branch, the typer knows that `from_profile.state` has type `PureCVState`,
-            # therefore `from_profile.replace(from_profile.state)` has type `StellarProfile[PureCVState]`.
-            return max_trace_distance_precision_pure_pure_std(
+    match protocol:
+        # standard protocol
+        # requires both profiles explicitely
+        case Protocol.standard:
+            if from_profile is None:
+                raise ValueError(
+                    "`from_profile` cannot be None when assessing Gaussian conversion with a non-postselected protocol."
+                )
+            # pure -> pure case
+            if isinstance(from_profile.state, PureCVState):
+                # In this branch, the typer knows that `from_profile.state` has type `PureCVState`,
+                # therefore `from_profile.replace(from_profile.state)` has type `StellarProfile[PureCVState]`.
+                return max_trace_distance_precision_pure_pure_std(
+                    from_profile=from_profile.replace(from_profile.state), to_profile=to_profile, nb_copies=nb_copies
+                )
+            # mixed -> pure case
+            print(("state is mixed"))
+            assert isinstance(from_profile.state, HermitianCVOp)
+            return max_trace_distance_precision_mixed_pure_std(
                 from_profile=from_profile.replace(from_profile.state), to_profile=to_profile, nb_copies=nb_copies
             )
-        assert isinstance(from_profile.state, HermitianCVOp)
-        # TODO to be modified here for mixed states
-        return 3.0
-
-    elif protocol is Protocol.postselected:
-        # TODO check here what happens for mixed states
-        if from_profile is not None:
-            warnings.warn("`from_profile` is not used in assessing Gaussian conversion with a postselected protocol.")
-        if from_rank is None:
-            raise ValueError(
-                "`from_rank` has to be specified in assessing Gaussian conversion with a postselected protocol"
+        # postselected protocol
+        case Protocol.postselected:
+            # TODO implement here the logic for postselected protocol for mixed states
+            # can always take the square root manually if needed
+            if from_profile is not None:
+                warnings.warn(
+                    "`from_profile` is not used in assessing Gaussian conversion with a postselected protocol."
+                )
+            if from_rank is None:
+                raise ValueError(
+                    "`from_rank` has to be specified in assessing Gaussian conversion with a postselected protocol"
+                )
+            return max_trace_distance_precision_pure_pure_post(
+                to_profile=to_profile, from_rank=from_rank, nb_copies=nb_copies
             )
 
-        return max_trace_distance_precision_pure_pure_post(
-            to_profile=to_profile, from_rank=from_rank, nb_copies=nb_copies
-        )
-    else:
-        assert_never(protocol)
+        case _:
+            assert_never(protocol)
 
 
-# TODO discuss type refinement with Thierry
-
-# not necessarily same pure state...
+# not necessarily same pure state
 U = TypeVar("U", bound=PureCVState)
 V = TypeVar("V", bound=PureCVState)
+W = TypeVar("W", bound=HermitianCVOp)
 
 
 def max_trace_distance_precision_pure_pure_std(
     from_profile: StellarProfile[U], to_profile: StellarProfile[V], nb_copies: int
 ) -> float:
     """finding max trace distance for deterministic conversion between pure states with a fixed number of copies.
-    Eq. (34) [HFFC25]"""
+    Eq. (36) [HGFFC25]"""
     # logger.info("Starting deterministicGaussian conversion analysis...")
     # avoid recomputing this
     max_rank_from = max(from_profile.profile.keys())
@@ -90,23 +96,48 @@ def max_trace_distance_precision_pure_pure_std(
 
     max_n = min([max_rank_from, max_rank_to // nb_copies])  # floor taken by integer division
 
-    print(f"{max_n=}")
+    # print(f"{max_n=}")
     distance_list: list[float] = []
 
-    # do we need to know the n giving the max?
     for n in range(0, max_n + 1):
         distance_list.append(1 - to_profile.profile[nb_copies * n] - nb_copies * (1 - from_profile.profile[n]))
     print(f"{distance_list=}")
     return max(distance_list)
 
 
+def max_trace_distance_precision_mixed_pure_std(
+    from_profile: StellarProfile[W], to_profile: StellarProfile[V], nb_copies: int
+) -> float:
+    """finding max trace distance for deterministic conversion from a mixed state to a pure state with a fixed number of copies.
+    Eq. (38) [HGFFC25]"""
+    max_rank_from = max(from_profile.profile.keys())
+    max_rank_to = max(to_profile.profile.keys())
+
+    max_n = min([max_rank_from, max_rank_to // nb_copies])  # floor taken by integer division
+
+    # print(f"{max_n=}")
+    distance_list: list[float] = []
+
+    for n in range(0, max_n + 1):
+        distance_list.append((1 - to_profile.profile[nb_copies * n] - nb_copies * (1 - from_profile.profile[n])) ** 2)
+    print(f"{distance_list=}")
+    # return max(distance_list)
+
+
 def max_trace_distance_precision_pure_pure_post(
     to_profile: StellarProfile[V], from_rank: int, nb_copies: int
 ) -> float:  # or None, error
     """finding max trace distance for postselected conversion between pure states with a fixed number of copies.
-    The actual profile of the target state is not required (only the stellar rank) since it is a looser bound see Eq. (35) [HFFC25]."""
+    The actual profile of the target state is not required (only the stellar rank) since it is a looser bound see Eq. (37) [HFFC25]."""
 
     return 1 - to_profile.profile[nb_copies * from_rank]
 
 
-# TODO add from mixed state converison bounds
+def max_trace_distance_precision_mixed_pure_post(
+    to_profile: StellarProfile[W], from_rank: int, nb_copies: int
+) -> float:  # or None, error
+    """finding max trace distance for postselected conversion from a mixed state to a pure state with a fixed number of copies.
+    The actual profile of the target state is not required (only the stellar rank) since it is a looser bound see Eq. (39) [HFFC25]."""
+
+    return (1 - to_profile.profile[nb_copies * from_rank]) ** 2
+

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -1,14 +1,14 @@
 """test conversion module"""
 
 from math import isclose
-import time
 from stellar.conversion import (
     max_trace_distance_precision,
+    max_trace_distance_precision_mixed_pure_std,
     max_trace_distance_precision_pure_pure_post,
     max_trace_distance_precision_pure_pure_std,
     Protocol,
 )
-from stellar.cvstates import CatState, CoherentState, FockState, GKPState, HermitianCVOp, PureDecompositionData
+from stellar.cvstates import CatState, CoherentState, FockState, HermitianCVOp, PureDecompositionData
 from stellar.params import Method, OptimisationParameters
 from stellar.profile import compute_profile
 import pytest
@@ -66,7 +66,8 @@ def test_det_conversion_fail_mixed() -> None:
         )
 
 
-def test_det_conversion() -> None:
+def test_pure_det_conversion() -> None:
+    """coherent state has rank 0 so the trace distance is decreasing in n, . Max is reached for k.n = 0."""
     from_state = CoherentState(amplitude=3)
     to_state = CatState(amplitude=1, parity=False)
 
@@ -77,7 +78,7 @@ def test_det_conversion() -> None:
     from_profile = compute_profile(ranks=list(range(max_rank)), target_state=from_state, optim_params=pars)
     to_profile = compute_profile(ranks=list(range(max_rank)), target_state=to_state, optim_params=pars)
     max_dist = max_trace_distance_precision_pure_pure_std(from_profile=from_profile, to_profile=to_profile, nb_copies=2)
-    print(f"{max_dist=} and {1 - to_profile.profile[0]}")  # need 1 - f_0(cat)
+    print(f"{max_dist=} and {1 - to_profile.profile[0]}")
 
     assert isclose(max_dist, 1 - to_profile.profile[0], abs_tol=1e-8)
 
@@ -89,42 +90,11 @@ def test_det_conversion() -> None:
     # assert False
 
 
-@pytest.mark.skip
-def test_det_conversion_paper() -> None:
-    from_state = CatState(amplitude=1, parity=False)  # 6
-    to_state = GKPState(delta=0.3, kappa=0.3)  # more terms (11 vs 4) than Δ = κ = 0.3
-
-    max_rank = 1
-    # same parameters for both states
-    pars = OptimisationParameters(method=Method.gaussian, niter=350)
-    init = time.time()
-    from_profile = compute_profile(ranks=list(range(max_rank)), target_state=from_state, optim_params=pars)
-    from_time = time.time()
-    print(f"from profile time {from_time - init}")
-    to_profile = compute_profile(ranks=list(range(max_rank)), target_state=to_state, optim_params=pars)
-    print(f"to_profile {to_profile.profile}")
-    to_time = time.time()
-    print(f"to profile time {to_time - from_time}")
-
-    from_profile.save_to_file("test")
-    to_profile.save_to_file("gkp33350")
-    # with open("gkp33350" + ".json", "w") as f:
-    #     json.dump(to_profile.profile, f)
-    dist_time = time.time()
-    max_dist = max_trace_distance_precision_pure_pure_std(from_profile=from_profile, to_profile=to_profile, nb_copies=1)
-    print(f"{max_dist=}")  # expect something around 0.23
-    print(f"dist time {dist_time - to_time}")
-    assert False
-
-
-def test_det_conversion_post() -> None:
+def test_pure_conversion_post() -> None:
     """test conversion from rank 1 to even cat state amp"""
     # check for 3 copies with Rui's value: 1-f_3(cat) = 1-0.896384 ≅ 0.103616
-    # from_state = CoherentState(amplitude=3)
     true_value = 1 - 0.896384
-    to_state = CatState(
-        amplitude=3, parity=False
-    )  # sqrt(4) = √4 gives 0.021810 kind of ok conversion paper [HFFC25] Fig. 4.
+    to_state = CatState(amplitude=3, parity=False)
 
     max_rank = 5
     # same parameters for both states
@@ -153,3 +123,43 @@ def test_det_conversion_post() -> None:
     assert isclose(max_dist, true_value, abs_tol=1e-5)
     assert isclose(max_dist, max_dist_2, abs_tol=1e-8)
     # assert False
+
+
+@pytest.mark.parametrize("prob", [0, 0.0032, 0.249, 0.33337, 0.491, 0.5601, 0.6662, 0.7831, 0.91673645, 1])
+def test_mixed_det_conversion(prob: float) -> None:
+    """Test if it works. For those parameters, it seems the n = 0 case yields the max distance.
+
+    Parameters
+    ----------
+    prob : float
+        probability parameter in input state
+    """
+
+    decomp: PureDecompositionData = (
+        (prob, FockState(n=0)),
+        (1 - prob, FockState(n=1)),
+    )
+
+    from_state = HermitianCVOp(data=decomp)
+    from_pars = OptimisationParameters(method=Method.fock, target_cutoff=6)
+    to_state = CatState(amplitude=1, parity=False)
+    to_pars = OptimisationParameters(method=Method.gaussian)
+
+    max_rank = 10
+
+    from_profile = compute_profile(ranks=list(range(max_rank)), target_state=from_state, optim_params=from_pars)
+    to_profile = compute_profile(ranks=list(range(max_rank)), target_state=to_state, optim_params=to_pars)
+
+    max_dist = max_trace_distance_precision_mixed_pure_std(
+        from_profile=from_profile, to_profile=to_profile, nb_copies=2
+    )
+
+    # print(f"{max_dist=} and {1 - to_profile.profile[0]}")
+
+    assert isclose(max_dist, (1 - to_profile.profile[0] - 2 * (1 - from_profile.profile[0])) ** 2, abs_tol=1e-8)
+
+    max_dist_2 = max_trace_distance_precision(
+        protocol=Protocol.standard, nb_copies=2, to_profile=to_profile, from_profile=from_profile
+    )
+    # print(f"{max_dist=} and {max_dist_2}")
+    assert isclose(max_dist, max_dist_2)


### PR DESCRIPTION
This PR adds the computation of deterministic Gaussian conversion bounds for mixed state input of stellar rank at most.
As a side benefit, I refactored the `conversion` logic using `match`/`case` syntax instead of `if`/`else`.